### PR TITLE
Feature/issue-10: Added CF manipulation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,10 @@
-foo:
-	python3 run_melkit.py ./sample_files/sample1.inp
-run:
-	python3 run_melkit.py ./sample_files/sample3.inp
 gen: clean
-	./melgen-fusion-186_bdba ./sample_files/sample3.inp
+	./melgen-fusion-186_bdba ./sample_files/sample1.inp
 cor:
-	./melcor-fusion-186_bdba ./sample_files/sample3.inp
+	./melcor-fusion-186_bdba ./sample_files/sample1.inp
 test: clean
-	./melgen-fusion-186_bdba ./sample_files/sample3.inp
-	./melcor-fusion-186_bdba ./sample_files/sample3.inp
+	./melgen-fusion-186_bdba ./sample_files/sample1.inp
+	./melcor-fusion-186_bdba ./sample_files/sample1.inp
 clean:
 	rm -f *.DIA
 	rm -f *.MES

--- a/docs/source/code/aux_tools.py
+++ b/docs/source/code/aux_tools.py
@@ -23,3 +23,10 @@ toolkit.get_available_ids(fls)
 # Get connections for a given CV
 toolkit.get_fl_connections(cv)
 toolkit.get_connected_cvs(cv)
+
+# Recursively, obtain related CFs
+for cf in toolkit.get_connected_cfs('FL001'):
+    print(cf)
+
+for cf in toolkit.get_connected_cfs('CF001'):
+    print(cf)

--- a/docs/source/code/read.py
+++ b/docs/source/code/read.py
@@ -15,3 +15,7 @@ for cv in toolkit.get_cv_list():
 # Read and show FLs in file
 for fl in toolkit.get_fl_list():
     print(fl)
+
+# Read and show CFs in file
+for cf in toolkit.get_cf_list():
+    print(cf)

--- a/melkit/inputs.py
+++ b/melkit/inputs.py
@@ -32,6 +32,15 @@ class Object():
 
     def __eq__(self, other):
         return self.get_id() == other.get_id()
+    
+    def __str__(self):
+        obj_str = []
+        for record, fields in self.records.items():
+            obj_str.append(f'{record}\t')
+            for value in fields.values():
+                obj_str.append(f'{value}\t')
+            obj_str.append('\n')
+        return ''.join(obj_str)
 
 
 class CV(Object):
@@ -55,11 +64,8 @@ class FL(Object):
     '''
     Flow Path class (FL package).
     '''
-    def __str__(self):
-        fl_str = []
-        for record, fields in self.records.items():
-            fl_str.append(f'{record}\t')
-            for value in fields.values():
-                fl_str.append(f'{value}\t')
-            fl_str.append('\n')
-        return ''.join(fl_str)
+
+class CF(Object):
+    '''
+    Control Function class (CF package).
+    '''

--- a/sample_files/sample2.inp
+++ b/sample_files/sample2.inp
@@ -18,7 +18,8 @@ NCG555    AR    8
 CF10000   QP  EQUALS  1  0.0  35.64601176           
 CF10010   1.0  0.0  TIME
 CF10100   RJ  MULTIPLY  1  0.3                      
-CF10110   1.0  0.0  CFVALU.100                      
+CF10110   1.0  0.0  CFVALU.100
+*                     
 CF10200   QT  EQUALS  1  1.0                        
 CF10210   1.0  0.0  CFVALU.103
 CF10300   Q-LLC  EQUALS  1  0.0  11747.14318        
@@ -196,18 +197,22 @@ FL200S0   0.001341   7.5    0.038
 FL200T0   2  200           
 CF20000   VEL-ArSS  EQUALS  1  0.0  0.1735                      
 CF20010   1.0  0.0  TIME
+
 FL20100   SGS-FL201   903   904   6.2  6.2
 FL20101   0.43709  10.0   1.0    0.746    0.746              
 FL20102	  3     0    0     0                                
 FL20103   0.0   0.0                                                           
 FL201S0   0.43709   10.0    0.746                               
-FL201T0   2   201                                   
+FL201T0   2   201 
+
 CF20100   VEL-FL201  DIVIDE  2  1.0                             
 CF20110   0.0  1573.524  TIME                                   
 CF20115   1.0  0.0  CFVALU.202
+
 CF20200   NUM-201  ADD  2  1.0
 CF20210   1.0  0.0  CFVALU.102
 CF20215   -1.0  0.0  CFVALU.100
+
 FL20200   SGS-FL202   904   905   6.7    6.7
 FL20201   0.43709  5.0   1.0    0.746    0.746              
 FL20202	  3     0    0     0                                
@@ -330,9 +335,11 @@ CF16415   3600.0  0.0  FL-MFLOW.5.207
 CF16500   ArPu-H2O-ppm DIVIDE 2 1.0E6                               
 CF16510   1.0  0.0  CFVALU.168                                                                                                           
 CF16515   3600.0  0.0  FL-MFLOW.3.207
+
 CF16600  Denom-163 MULTIPLY 2 1.0
 CF16610  1.0  0.0  CFVALU.153
 CF16615  1.0  0.0  CFVALU.300
+
 CF16700  Denom-164 MULTIPLY 2 1.0
 CF16710  1.0  0.0  CFVALU.154
 CF16715  1.0  0.0  CFVALU.300


### PR DESCRIPTION
Closes #10 

The following features related to `CF` manipulation have been added:

- New `CF` input class.
- `CF` reading, writing and editing methods for `Toolkit` class.
- Added a new `Toolkit` method (`get_connected_cfs(Object_id)`) for recursively extract inter-connected `CF`:
        - If the `Object` is `FL`, the `CF` associated with the `CFnnnTk` record is returned and, recursively, all `CF` on which this `CF` depends are added.
        - If the object is a `CF`, that `CF` and its dependencies are returned.
- Documentation updated with usage examples.